### PR TITLE
fix replaceSelectionWith when inheritMarks param is missing

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -120,7 +120,7 @@ class Transaction extends Transform {
   // inserted.
   replaceSelectionWith(node, inheritMarks) {
     let selection = this.selection
-    if (inheritMarks !== false)
+    if (inheritMarks)
       node = node.mark(this.storedMarks || selection.$from.marks(selection.to > selection.from))
     selection.replaceWith(this, node)
     return this


### PR DESCRIPTION
When `inheritMarks` param is missing, it's value is undefined, which is not equal to false. It breaks pasting of links in case this is a single node.

doPaste -> replaceSelectionWith. It swallows all marks from the node.