### PR TITLE
Fix documentation NodeSelection.create

### DIFF
--- a/src/selection.js
+++ b/src/selection.js
@@ -376,7 +376,7 @@ class NodeSelection extends Selection {
     return new NodeSelection(doc.resolve(json.anchor))
   }
 
-  // :: (Node, number, ?number) → TextSelection
+  // :: (Node, number, ?number) → NodeSelection
   // Create a node selection from non-resolved positions.
   static create(doc, from) {
     return new this(doc.resolve(from))


### PR DESCRIPTION
Minor typo, `NodeSelection.create` should be documented as returning type `NodeSelection`, not `TextSelection`