### PR TITLE
Always supply an array to node.mark()

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -133,7 +133,7 @@ export class Transaction extends Transform {
   replaceSelectionWith(node, inheritMarks) {
     let selection = this.selection
     if (inheritMarks !== false)
-      node = node.mark(this.storedMarks || (selection.empty ? selection.$from.marks() : selection.$from.marksAcross(selection.$to)))
+      node = node.mark(this.storedMarks || (selection.empty ? selection.$from.marks() : (selection.$from.marksAcross(selection.$to) || Mark.none)))
     selection.replaceWith(this, node)
     return this
   }


### PR DESCRIPTION
This branch fixes a bug where non-marked nodes would needlessly cause a node to be re-created, because `node.marksAcross()` can return null (but `node.mark()` expects an array of marks).