### PR TITLE
fixing toJSON when called by JSON.stringify

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -210,13 +210,13 @@ export class EditorState {
     return instance
   }
 
-  // :: (?Object<Plugin>) → Object
+  // :: (?union<Object<Plugin>, string>) → Object
   // Serialize this state to JSON. If you want to serialize the state
   // of plugins, pass an object mapping property names to use in the
   // resulting JSON object to plugin objects.
   toJSON(pluginFields) {
     let result = {doc: this.doc.toJSON(), selection: this.selection.toJSON()}
-    if (pluginFields) for (let prop in pluginFields) {
+    if (pluginFields && typeof pluginFields == 'object') for (let prop in pluginFields) {
       if (prop == "doc" || prop == "selection")
         throw new RangeError("The JSON fields `doc` and `selection` are reserved")
       let plugin = pluginFields[prop], state = plugin.spec.state

--- a/test/test-state.js
+++ b/test/test-state.js
@@ -101,6 +101,11 @@ describe("State", () => {
     ist(applied.state.doc, doc(p("XA")), eq)
     ist(applied.transactions.length, 2)
   })
+
+  it("supports JSON.stringify toJSON arguments", () => {
+    let someObject = { someKey: EditorState.create({schema}) }
+    ist(JSON.stringify(someObject).length > 0)
+  })
 })
 
 describe("Plugin", () => {


### PR DESCRIPTION
This fixes an error that can be thrown if you try to stringify the EditorState inside of parent object. Per the [JSON.stringify docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON()_behavior):

> the value returned by the toJSON() method when called will be serialized. JSON.stringify() calls toJSON with one parameter:
> - if this object is a property value, the property name
> - if it is in an array, the index in the array, as a string
> - an empty string if JSON.stringify() was directly called on this object

This allows the status quo `pluginFields` behavior, while still being compatible w/ `JSON.stringify`.