### PR TITLE
Fix `getBookmark` bug

### DIFF
--- a/src/selection.js
+++ b/src/selection.js
@@ -193,7 +193,7 @@ export class Selection {
   // this method just converts the selection to a text selection and
   // returns the bookmark for that.
   getBookmark() {
-    return TextSelection.between(this.anchor, this.head).getBookmark()
+    return TextSelection.between(this.$anchor, this.$head).getBookmark()
   }
 }
 


### PR DESCRIPTION
I've been banging my head against 'can't read property inlineContent of undefined' for a while and I think I may have found the culprit. It seems `Selection.between` expects a `ResolvedPos` but here `getBookmark` was passing the number of a pos instead.  This was being fired by `prosemirror-history`. I think this slipped under the radar because it's looks like it only fires in certain history grouping scenarios cases but even then I'm surprised this hasn't surfaced earlier so am a bit confused! Either way, it fixes a couple of tests I've been struggling with.