### PR TITLE
Pass the root transaction to appendedTransaction meta

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -112,10 +112,10 @@ export class EditorState {
   // be influenced by the [transaction
   // hooks](#state.PluginSpec.filterTransaction) of
   // plugins) along with the new state.
-  applyTransaction(tr) {
-    if (!this.filterTransaction(tr)) return {state: this, transactions: []}
+  applyTransaction(rootTr) {
+    if (!this.filterTransaction(rootTr)) return {state: this, transactions: []}
 
-    let trs = [tr], newState = this.applyInner(tr), seen = null
+    let trs = [rootTr], newState = this.applyInner(rootTr), seen = null
     // This loop repeatedly gives plugins a chance to respond to
     // transactions as new transactions are added, making sure to only
     // pass the transactions the plugin did not see before.
@@ -128,7 +128,7 @@ export class EditorState {
           let tr = n < trs.length &&
               plugin.spec.appendTransaction.call(plugin, n ? trs.slice(n) : trs, oldState, newState)
           if (tr && newState.filterTransaction(tr, i)) {
-            tr.setMeta("appendedTransaction", tr)
+            tr.setMeta("appendedTransaction", rootTr)
             if (!seen) {
               seen = []
               for (let j = 0; j < this.config.plugins.length; j++)

--- a/test/test-state.js
+++ b/test/test-state.js
@@ -103,6 +103,23 @@ describe("State", () => {
   })
 
   it("allows plugins to append transactions", () => {
+    let tr
+    let state = EditorState.create({plugins: [
+      new Plugin({
+        appendTransaction: (trs, oldState, newState) =>
+          newState.tr.insertText("Y")
+      }),
+      new Plugin({
+        appendTransaction: trs => {
+          ist(tr, trs[1].getMeta("appendedTransaction"))
+        }
+      })
+    ], schema})
+    tr = state.tr.insertText("X")
+    state.applyTransaction(tr)
+  })
+
+  it("stores a reference to a rootTransaction for appended transactions", () => {
     let state = EditorState.create({plugins: [transactionPlugin], schema})
     let applied = state.applyTransaction(state.tr.insertText("X").setMeta("append", true))
     ist(applied.state.doc, doc(p("XA")), eq)


### PR DESCRIPTION
This passes the transaction that started all of the plugin transactions to `appendedTransaction` rather than a circular reference to itself, specifically for https://github.com/ProseMirror/prosemirror-history/pull/3 to fix ProseMirror/prosemirror#819