### PR TITLE
Feature: add ability to call custom transaction functions

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -41,6 +41,14 @@ export class Transaction extends Transform {
     this.meta = Object.create(null)
   }
 
+  // :: ((Transaction, ...args: *)) → Transaction
+  // Applies the given function to the transaction. The function must
+  // take a [`Transaction`](#state.Transaction) as its first argument.
+  chain(transactionFunction, ...args) {
+    transactionFunction(this, ...args)
+    return this
+  }
+
   // :: Selection
   // The transaction's current selection. This defaults to the editor
   // selection [mapped](#state.Selection.map) through the steps in the

--- a/test/test-state.js
+++ b/test/test-state.js
@@ -44,6 +44,15 @@ describe("State", () => {
     ist(newState.selection.from, 3)
   })
 
+  it("applies transaction with custom transformation", () => {
+    let state = EditorState.create({schema})
+    let fn = (transaction, text) => transaction.insertText(text)
+    let newState = state.apply(state.tr.chain(fn, "hi"))
+    ist(state.doc, doc(p()), eq)
+    ist(newState.doc, doc(p("hi")), eq)
+    ist(newState.selection.from, 3)
+  });
+
   it("supports plugin fields", () => {
     let state = EditorState.create({plugins: [messageCountPlugin], schema})
     let newState = state.apply(state.tr).apply(state.tr)


### PR DESCRIPTION
We'd like to be able to abstract away complex operations on transactions and still be able to chain them as part of a sequence of operations along with other simpler operations. Here's a simple example use case.
```
function insertTextOrSetSelection(tr, text, anchor, head, doInsert) {
    return doInsert
        ? tr.insertText(text) 
        : tr.setSelection(TextSelection.create(tr.doc, anchor, head))
}

// what we want to be able to do
state.tr
    .chain(insertTextOrSetSelection, 'first', 1, 2, getDoInsert())
    .insertText('second')

// current workaround
const tr = state.tr
insertTextOrSetSelection(tr, 'first', 1, 2, getDoInsert())
tr.insertText('second')
```
You could imagine the branching logic within the custom function being a lot more complex, and maybe you'd even want to be able to chain multiple of them together.

Since this is my first time contributing to prosemirror, I wasn't sure if we want features to have an associated ticket in the github issue tracker, or only bugs. If so, I'll create one and link it to this.