### PR TITLE
Flexible plugins configuration

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -45,7 +45,7 @@ class Configuration {
     this.fields = baseFields.concat()
     this.plugins = []
     this.pluginsByKey = Object.create(null)
-    if (plugins) plugins.forEach(plugin => {
+    if (plugins) plugins.filter(Boolean).forEach(plugin => {
       if (this.pluginsByKey[plugin.key])
         throw new RangeError("Adding different instances of a keyed plugin (" + plugin.key + ")")
       this.plugins.push(plugin)


### PR DESCRIPTION
The reason to do so:

1. plugins's order is important(influence the invoke order of transactions, events, etc)
2. when need to disable some plugin in first loading by some config, there is no way to do it

So is the way below is more flexible plugins configuration?

```js
let isAndroid = true; // some config pass by useragent or something else;
let somePlugin = xxx;
let state = EditorState.create({
  schema,
  props,
  plugins: [
    isAndroid ? somePlugin : null,
    otherPlugin
  ]
});
```