### PR TITLE
feat: Add exports.types to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
+    "types": "./dist/index.d.ts",
     "import": "./dist/index.js",
     "require": "./dist/index.cjs"
   },


### PR DESCRIPTION
This allows TypeScript to correctly resolve type imports when using Node's module resolution with:
*   `"moduleResolution": "NodeNext"`, or
*   `"moduleResolution": "Node16"`

Refs:
*   [Typescript docs](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing)
*   [Node docs](https://nodejs.org/api/packages.html#community-conditions-definitions)