### PR TITLE
FIX: Fixed an issue with explicit value assignment due to babel trasp…

### DIFF
--- a/src/selection.ts
+++ b/src/selection.ts
@@ -184,7 +184,7 @@ export abstract class Selection {
   /// Controls whether, when a selection of this type is active in the
   /// browser, the selected range should be visible to the user.
   /// Defaults to `true`.
-  visible!: boolean
+  visible: boolean = true;
 }
 
 Selection.prototype.visible = true


### PR DESCRIPTION
@marijnh 

This is a continuation of the conversation on this [pull request](https://github.com/ProseMirror/prosemirror-view/pull/155)

After a detailed investigation, the cause of the unexpected behavior was discovered if a babel transpiler was used in the stack. 

Here is a problem demonstration with an example of code within the `Selection` class constructor with a `visible` property using Babel with [plugin](https://babeljs.io/docs/babel-plugin-proposal-class-properties).

```
 `constructor(
    $anchor,
    $head, ranges) {
      _defineProperty(this, "ranges", void 0);
      _defineProperty(this, "visible", void 0); --> PROBLEM
      this.$anchor = $anchor;
      this.$head = $head;
      this.ranges = ranges || [new SelectionRange($anchor.min($head), $anchor.max($head))];
    }`
```

This definition of property within the constructor actually overrides the default `true` value and causes unexpected selection behavior in all parts of the application which is demonstrated in attachment within previous [PR](https://github.com/ProseMirror/prosemirror-view/pull/155).

The problem was solved by explicitly setting the value (`true`) to the `visible` property in the Selection class.

```
`class Selection {
  visible = true
}`
```
