### PR TITLE
Fix selection visible property declaration

### DIFF
--- a/src/selection.ts
+++ b/src/selection.ts
@@ -184,7 +184,7 @@ export abstract class Selection {
   /// Controls whether, when a selection of this type is active in the
   /// browser, the selected range should be visible to the user.
   /// Defaults to `true`.
-  visible!: boolean
+  declare visible: boolean
 }
 
 Selection.prototype.visible = true


### PR DESCRIPTION
The usage of `!` in property declaration causes inconsistent TS compiler output, depending on the `useDefineForClassFields` compiler flag. If the `useDefineForClassFields` flag is `true` - `selection.visible` property will resolve to `undefined`, as the prototype value is being overwritten in the class constructor.

Since the `!` is here only to declare that the property exists, and not to assume not-nullness -> it would be more appropriate to use `declare` statement instead. This is also a prevention of a future problem when TS switches to `useDefineForClassFields` as a default compiler behavior.