### PR TITLE
chore(docs): add clarification that state.tr is an accessor

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -178,7 +178,7 @@ export class EditorState {
     return newInstance
   }
 
-  /// Start a [transaction](#state.Transaction) from this state.
+  /// Accessor that constructs and returns a new [transaction](#state.Transaction) from this state.
   get tr(): Transaction { return new Transaction(this) }
 
   /// Create a new state.


### PR DESCRIPTION
In the past, I had issues for a while trying to figure out why I couldn't use `state.tr` directly, and had to reassign it. I think the most legible would be `state.tr()` or `state.createTransaction()` where it would be expected to be a different memory reference each time, but adding a little more detail in the comment should help others.