### PR TITLE
Remove redundant null check in insertText

### DIFF
--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -169,7 +169,6 @@ export class Transaction extends Transform {
       return this.replaceSelectionWith(schema.text(text), true)
     } else {
       if (to == null) to = from
-      to = to == null ? from : to
       if (!text) return this.deleteRange(from, to)
       let marks = this.storedMarks
       if (!marks) {


### PR DESCRIPTION
The following two lines have duplicated functionality. I removed one of them. 

```
      if (to == null) to = from
      to = to == null ? from : to
```